### PR TITLE
Fix crash due to bad handling of self as delegate/datasource

### DIFF
--- a/GNESectionedTableView/Views/GNESectionedTableView.h
+++ b/GNESectionedTableView/Views/GNESectionedTableView.h
@@ -526,4 +526,8 @@ didSelectRowAtIndexPath:(NSIndexPath * __nonnull)indexPath;
 #pragma mark - Scrolling
 - (void)scrollRowAtIndexPathToVisible:(NSIndexPath * __nonnull)indexPath;
 
+#pragma mark - Unavailable
+@property (nullable, weak) id <NSOutlineViewDelegate> delegate NS_UNAVAILABLE;
+@property (nullable, weak) id <NSOutlineViewDataSource> dataSource NS_UNAVAILABLE;
+
 @end

--- a/GNESectionedTableView/Views/GNESectionedTableView.m
+++ b/GNESectionedTableView/Views/GNESectionedTableView.m
@@ -111,6 +111,8 @@ typedef NS_ENUM(NSUInteger, GNEDragLocation)
 @dynamic selectedIndexPath;
 @dynamic selectedIndexPaths;
 
+@dynamic dataSource;
+@dynamic delegate;
 
 // ------------------------------------------------------------------------------------------
 #pragma mark - Initialization
@@ -158,8 +160,8 @@ typedef NS_ENUM(NSUInteger, GNEDragLocation)
     
     _rowViewToIndexPathMap = [NSMutableDictionary dictionary];
     
-    self.dataSource = self;
-    self.delegate = self;
+    super.dataSource = self;
+    super.delegate = self;
     
     self.wantsLayer = YES;
     self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawOnSetNeedsDisplay;
@@ -201,6 +203,9 @@ typedef NS_ENUM(NSUInteger, GNEDragLocation)
     
     _tableViewDataSource = nil;
     _tableViewDelegate = nil;
+
+    super.dataSource = nil;
+    super.delegate = nil;
 }
 
 
@@ -3858,33 +3863,6 @@ typedef NS_ENUM(NSUInteger, GNEDragLocation)
 - (BOOL)isUpdating
 {
     return (self.updateCount > 0);
-}
-
-
-// ------------------------------------------------------------------------------------------
-#pragma mark - NSOutlineView - Accessors
-// ------------------------------------------------------------------------------------------
-- (id <NSOutlineViewDataSource>)dataSource
-{
-    return self;
-}
-
-
-- (void)setDataSource:(id<NSOutlineViewDataSource> __unused)aSource
-{
-    [super setDataSource:self];
-}
-
-
-- (id <NSOutlineViewDelegate>)delegate
-{
-    return self;
-}
-
-
-- (void)setDelegate:(id<NSOutlineViewDelegate> __unused)anObject
-{
-    [super setDelegate:self];
 }
 
 

--- a/GNESectionedTableViewTests/Table View/GNESectionedTableViewTests.m
+++ b/GNESectionedTableViewTests/Table View/GNESectionedTableViewTests.m
@@ -62,15 +62,17 @@
 // ------------------------------------------------------------------------------------------
 - (void)testTableViewDataSourceIsSelf
 {
-    XCTAssertNotNil(self.tableView.dataSource);
-    XCTAssertEqualObjects(self.tableView.dataSource, self.tableView);
+    NSOutlineView *outlineView = (NSOutlineView *)self.tableView;
+    XCTAssertNotNil(outlineView.dataSource);
+    XCTAssertEqualObjects(outlineView.dataSource, self.tableView);
 }
 
 
 - (void)testTableViewDelegateIsSelf
 {
-    XCTAssertNotNil(self.tableView.delegate);
-    XCTAssertEqualObjects(self.tableView.delegate, self.tableView);
+    NSOutlineView *outlineView = (NSOutlineView *)self.tableView;
+    XCTAssertNotNil(outlineView.delegate);
+    XCTAssertEqualObjects(outlineView.delegate, self.tableView);
 }
 
 


### PR DESCRIPTION
This crash occurs when quickly double-clicking an item or running the unit tests on Sierra. The reference to self is not valid in animation handler, since it has been dealloced. Instead of overriding the setter and getter, go through the super class (NSOutlineView).

Also update the unit tests to work and pass with new changes.